### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,13 @@ jobs:
         token: ${{ secrets.PAT }}
 
     - name: Setup Nix
-      uses: DeterminateSystems/nix-installer-action@v17
+      uses: nixbuild/nix-quick-install-action@v30
 
     - name: Setup Nix cache
-      uses: DeterminateSystems/magic-nix-cache-action@v9
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
     - name: Setup Git
       run: |
@@ -79,10 +82,13 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Nix
-      uses: DeterminateSystems/nix-installer-action@v17
+      uses: nixbuild/nix-quick-install-action@v30
 
     - name: Setup Nix cache
-      uses: DeterminateSystems/magic-nix-cache-action@v9
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
     - name: Run Nix build
       run: nix build


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.
